### PR TITLE
CI: fix python-lib-ci

### DIFF
--- a/.github/workflows/ci_python_reusable.yml
+++ b/.github/workflows/ci_python_reusable.yml
@@ -14,6 +14,10 @@ jobs:
     runs-on: ubuntu-22.04
     timeout-minutes: 30
 
+    defaults:
+      run:
+        working-directory: ${{ inputs.working-directory }}
+
     steps:
       - name: Checkout
         uses: actions/checkout@v3
@@ -29,7 +33,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           pip install -r "$(git rev-parse --show-toplevel)/pip-requirements.txt"
-          pip install -r "$(git rev-parse --show-toplevel)/dev-requirements.txt"
+          pip install -r "$(git rev-parse --show-toplevel)/dev-requirements.txt" -r requirements.txt
 
       - name: Typecheck
         run: |


### PR DESCRIPTION
* Change the workdir of all steps to be the one in input by default.
* Add missing requirements file in pip install command

#### How to trust this PR?

The following updated test passes
https://github.com/tweag/python-monorepo-example/actions/runs/4488164411/jobs/7892434379