### PR TITLE
Align CI with blogpost

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,16 +32,17 @@ jobs:
 
       - name: Format Python imports
         run: |
-          isort --check-only .
+          isort --check-only $(git ls-files "*.py")
 
       - name: Format Python
         run: |
-          black --check .
+          black --check $(git ls-files "*.py")
 
       - name: Lint Python
         run: |
-          flake8 .
+          flake8 $(git ls-files "*.py")
 
+      # Are all public symbols documented? (see top-level pyproject.toml configuration)
       - name: Lint Python doc
         run: |
-          pylint .
+          pylint $(git ls-files "*.py")

--- a/.github/workflows/ci_python_reusable.yml
+++ b/.github/workflows/ci_python_reusable.yml
@@ -1,5 +1,5 @@
 ---
-name: Reusable job for Python CI
+name: Reusable Python library CI
 
 on:
   workflow_call:
@@ -8,6 +8,16 @@ on:
         required: true
         type: string
         description: "From which folder this pipeline executes"
+      install-packages:
+        description: "Space seperated list of packages to install using apt-get."
+        default: ""
+        type: string
+      # To avoid being billed 360 minutes if a step does not terminate
+      # (we've seen the setup-python step below do so!)
+      ci-timeout:
+        description: "The timeout of the ci job. Default is 25min"
+        default: 25
+        type: number
 
 jobs:
   python-lib-ci:
@@ -28,7 +38,17 @@ jobs:
         uses: actions/setup-python@v4
         timeout-minutes: 5
         with:
-          python-version: ${{ inputs.python-version }}
+          python-version-file: ${{ github.workspace }}/.python-version
+          cache: "pip"
+          cache-dependency-path: |
+            dev-requirements.txt
+            pip-requirements.txt
+            ${{ inputs.working-directory }}/requirements.txt
+
+      - name: Install extra packages
+        if: ${{ inputs.install-packages != ''}}
+        run: |
+          sudo apt-get install -y ${{ inputs.install-packages }}
 
       - name: Install Python dependencies
         run: |


### PR DESCRIPTION
## What this PR does

* Use `$(git ls-files ..)` to find files, to avoid crawling venvs if tools aren't smart enough
* Use `.python-version` as source of truth for `setup-python`

## How to trust this PR

The CI is triggered and it passes.