### PR TITLE
Add mergify configuration

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,0 +1,29 @@
+queue_rules:
+  - name: default
+    conditions:
+
+pull_request_rules:
+  - name: automatic merge
+    conditions:
+      - "#approved-reviews-by>=1"
+      - "label=merge-queue"
+      - "base=main"
+    actions:
+      queue:
+        name: default
+        method: merge
+
+  - name: delete head branch after merge
+    conditions:
+      - merged
+      - closed
+    actions:
+      delete_head_branch: {}
+
+  - name: remove from merge-queue after merge
+    conditions:
+      - merged
+    actions:
+      label:
+        remove:
+          - "merge-queue"


### PR DESCRIPTION
## What this PR does

This PR adds the configuration of [mergify](https://mergify.com/), so that PRs can be merged automatically when the `merge-queue` label is used 

## How to trust this PR

I reused [rules_haskell](https://github.com/tweag/rules_haskell) configuration and I think I didn't screw up :sweat_smile: 

## How to test this PR

Add the `merge_queue` label and see it gets merged