### PR TITLE
Add base2 library (generated by template)

### DIFF
--- a/.github/workflows/ci_base2.yml
+++ b/.github/workflows/ci_base2.yml
@@ -1,0 +1,20 @@
+---
+name: CI libs/base
+
+on:
+  pull_request:
+    paths:
+      - 'dev-requirements.txt'
+      - 'pip-requirements.txt'
+      - '.github/workflows/ci_python_reusable.yml'
+      - '.github/workflows/ci_base2.yml'
+      - 'libs/base2/**'
+  workflow_dispatch:  # Allows to trigger the workflow manually in GitHub UI
+
+jobs:
+  libs-base2-ci:
+    uses:
+      ./.github/workflows/ci_python_reusable.yml
+    with:
+      working-directory: libs/base2
+    secrets: inherit

--- a/libs/base2/README.md
+++ b/libs/base2/README.md
@@ -1,0 +1,36 @@
+# base2
+
+A Python package by mycorp.
+
+The project owner is [smelc](https://github.com/smelc).
+
+## Development
+
+If not already in a virtual environement, create and use one.
+Read about it in the Python documentation: [venv — Creation of virtual environments](https://docs.python.org/3/library/venv.html).
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the pinned pip version:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/pip-requirements.txt
+```
+
+Finally, install the dependencies:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/dev-requirements.txt -r requirements.txt
+```
+
+## Testing
+
+Execute tests from the library's folder (after having loaded the virtual environment,
+see above) as follows:
+
+```
+python3 -m pytest tests/
+```

--- a/libs/base2/pyproject.toml
+++ b/libs/base2/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "mycorp-base2"
+version = "0.0.1"
+description = "A Python package by mycorp."
+authors = [
+    "Clément Hurlin <clement.hurlin@tweag.io>"
+]
+packages = [
+  { include = "mycorp" }
+]
+
+[tool.poetry.dependencies]
+python = ">=3.9"
+
+[tool.poetry.dev-dependencies]
+black = "^23.1.0"
+flake8 = "^6.0.0"
+isort = "^5.12.0"
+pylint = "^2.16.3"
+pyright = "^1.1.296"
+pytest = "^7.2.1"
+
+[tool.black]
+line-length = 100
+target-version = ['py39']
+
+[tool.pyright]
+
+[tool.pylint."messages control"]
+disable = "all"
+enable = ["empty-docstring", "missing-module-docstring", "missing-class-docstring", "missing-function-docstring"]
+ignore = ["setup.py", "__init__.py"]
+ignore-paths = ["tests"]

--- a/libs/base2/requirements.txt
+++ b/libs/base2/requirements.txt
@@ -1,0 +1,2 @@
+# Add pinned dependencies to install for development
+# Development dependencies (black, flake8, etc.) are in the top-level dev-requirements.txt file

--- a/libs/base2/setup.cfg
+++ b/libs/base2/setup.cfg
@@ -1,0 +1,1 @@
+# This file is empty, but is needed by setuptools to detect pyproject.toml (for now)

--- a/libs/base2/tests/conftest.py
+++ b/libs/base2/tests/conftest.py
@@ -1,0 +1,13 @@
+"""
+Shared configuration and fixtures for pytest.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def some_text() -> str:
+    """
+    Some fixture which can be reused in all test modules.
+    """
+    return "Some text"

--- a/libs/base2/tests/test_example.py
+++ b/libs/base2/tests/test_example.py
@@ -1,0 +1,8 @@
+"""
+An example of test module provided by the project template.
+"""
+
+
+def test_something():
+    """An example of test found and run by pytest."""
+    raise NotImplementedError("No test was implemented. Either remove this test or implement it.")


### PR DESCRIPTION
## What this PR does

This PR adds a library created by the [cookicutter]() template, to test that it's correct, to support the PR adding the template.

## How to trust this PR

Inspect the CI checks and witness that it checks things for the `base2` library:

![image](https://user-images.githubusercontent.com/634720/234332457-96b24e4f-53f0-498d-8c5b-467351661aba.png)