### PR TITLE
Add cookiecutter template to create new libraries

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,12 @@ jobs:
           pip install -r pip-requirements.txt
           pip install -r dev-requirements.txt
 
+      # in order to test the template as well, we create a temporary library in the CI
+      - name: Create library with template
+        run: |
+          cookiecutter --no-input templates/pylibrary --output-dir libs/
+          git add libs/library_name  # So that checks below apply to generated library
+
       - name: Format Python imports
         run: |
           isort --check-only $(git ls-files "*.py")

--- a/.mergify.yml
+++ b/.mergify.yml
@@ -1,6 +1,5 @@
 queue_rules:
   - name: default
-    conditions:
 
 pull_request_rules:
   - name: automatic merge

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,4 +1,5 @@
 black==23.1.0
+cookiecutter==2.1.1
 flake8==6.0.0
 isort==5.12.0
 pylint==2.16.3

--- a/libs/base/README.md
+++ b/libs/base/README.md
@@ -1,0 +1,36 @@
+# base
+
+A Python package by mycorp.
+
+The project owner is [@smelc](https://github.com/smelc).
+
+## Development
+
+If not already in a virtual environement, create and use one.
+Read about it in the Python documentation: [venv — Creation of virtual environments](https://docs.python.org/3/library/venv.html).
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the pinned pip version:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/pip-requirements.txt
+```
+
+Finally, install the dependencies:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/dev-requirements.txt -r requirements.txt
+```
+
+## Testing
+
+Execute tests from the library's folder (after having loaded the virtual environment,
+see above) as follows:
+
+```
+python3 -m pytest tests/
+```

--- a/libs/base/requirements.txt
+++ b/libs/base/requirements.txt
@@ -1,1 +1,4 @@
+# Add pinned dependencies to install for development
+# Development dependencies (black, flake8, etc.) are in the top-level dev-requirements.txt file
+
 numpy==1.22.0  # Actually unused, for demonstration only

--- a/libs/base/setup.cfg
+++ b/libs/base/setup.cfg
@@ -1,0 +1,1 @@
+# This file is empty, but is needed by setuptools to detect pyproject.toml (for now)

--- a/libs/base/tests/conftest.py
+++ b/libs/base/tests/conftest.py
@@ -1,0 +1,13 @@
+"""
+Shared configuration and fixtures for pytest.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def some_text() -> str:
+    """
+    Some fixture which can be reused in all test modules.
+    """
+    return "Some text"

--- a/libs/base/tests/test_example.py
+++ b/libs/base/tests/test_example.py
@@ -1,0 +1,8 @@
+"""
+An example of test module provided by the project template.
+"""
+
+
+def test_something():
+    """An example of test found and run by pytest."""
+    raise NotImplementedError("No test was implemented. Either remove this test or implement it.")

--- a/libs/fancy/README.md
+++ b/libs/fancy/README.md
@@ -1,0 +1,36 @@
+# fancy
+
+A Python package by mycorp.
+
+The project owner is by our gentleman [@GuillaumeDesforges](https://github.com/GuillaumeDesforges).
+
+## Development
+
+If not already in a virtual environement, create and use one.
+Read about it in the Python documentation: [venv — Creation of virtual environments](https://docs.python.org/3/library/venv.html).
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the pinned pip version:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/pip-requirements.txt
+```
+
+Finally, install the dependencies:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/dev-requirements.txt -r requirements.txt
+```
+
+## Testing
+
+Execute tests from the library's folder (after having loaded the virtual environment,
+see above) as follows:
+
+```
+python3 -m pytest tests/
+```

--- a/libs/fancy/requirements.txt
+++ b/libs/fancy/requirements.txt
@@ -1,1 +1,4 @@
+# Add pinned dependencies to install for development
+# Development dependencies (black, flake8, etc.) are in the top-level dev-requirements.txt file
+
 -e ../base

--- a/libs/fancy/setup.cfg
+++ b/libs/fancy/setup.cfg
@@ -1,0 +1,1 @@
+# This file is empty, but is needed by setuptools to detect pyproject.toml (for now)

--- a/libs/fancy/tests/conftest.py
+++ b/libs/fancy/tests/conftest.py
@@ -1,0 +1,13 @@
+"""
+Shared configuration and fixtures for pytest.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def some_text() -> str:
+    """
+    Some fixture which can be reused in all test modules.
+    """
+    return "Some text"

--- a/libs/fancy/tests/test_example.py
+++ b/libs/fancy/tests/test_example.py
@@ -1,0 +1,8 @@
+"""
+An example of test module provided by the project template.
+"""
+
+
+def test_something():
+    """An example of test found and run by pytest."""
+    raise NotImplementedError("No test was implemented. Either remove this test or implement it.")

--- a/templates/pylibrary/README.md
+++ b/templates/pylibrary/README.md
@@ -1,0 +1,39 @@
+# Python library template
+
+A cookiecutter template to create new Python libraries in the monorepo.
+
+## How to use
+
+### Without Nix
+
+Load the monorepo's top-level sandbox, that contains cookiecutter:
+
+```
+# From the monorepo root
+# Create the sandbox (only do that the first time)
+python3 -m venv .venv
+pip install -r pip-requirements.txt
+pip install -r dev-requirements.txt
+# Load the sandbox (todo every time)
+source .venv/bin/activate
+```
+
+Then run cookiecutter _from the root directory of the monorepo_:
+
+```
+cookiecutter templates/pylibrary --output-dir libs/
+```
+
+Notes:
+
+- When entering a package name or module name, do not include a 'mycorp-' prefix.
+- When entering your github handle, include the '@' prefix
+
+### With Nix
+
+Run cookiecutter _from the root directory of the monorepo_:
+
+```
+nix run nixpkgs#cookiecutter -- templates/pylibrary --output-dir libs/
+```
+

--- a/templates/pylibrary/cookiecutter.json
+++ b/templates/pylibrary/cookiecutter.json
@@ -1,0 +1,9 @@
+{
+  "library_name": "Library Name",
+  "package_name": "{{ cookiecutter.library_name.lower().replace(' ', '-') }}",
+  "module_name": "{{ cookiecutter.library_name.lower().replace(' ', '_').replace('-', '_') }}",
+  "package_description": "A Python package by mycorp.",
+  "owner_full_name": "Your full name",
+  "owner_email_address": "Your email address",
+  "owner_github_handle": "Your GitHub handle"
+}

--- a/templates/pylibrary/hooks/post_gen_project.py
+++ b/templates/pylibrary/hooks/post_gen_project.py
@@ -1,0 +1,28 @@
+"""Script to generate the CI a new library."""
+
+MODULE_NAME: str = "{{ cookiecutter.module_name }}"
+CI_FILE_PATH: str = f"../../.github/workflows/ci_{MODULE_NAME}.yml"
+
+with open(CI_FILE_PATH, "w") as handle:
+    handle.writelines(
+        f"""---
+name: CI libs/base
+
+on:
+  pull_request:
+    paths:
+      - 'dev-requirements.txt'
+      - 'pip-requirements.txt'
+      - '.github/workflows/ci_python_reusable.yml'
+      - '.github/workflows/ci_{MODULE_NAME}.yml'
+      - 'libs/{MODULE_NAME}/**'
+  workflow_dispatch:  # Allows to trigger the workflow manually in GitHub UI
+
+jobs:
+  libs-{MODULE_NAME}-ci:
+    uses:
+      ./.github/workflows/ci_python_reusable.yml
+    with:
+      working-directory: libs/{MODULE_NAME}
+    secrets: inherit"""
+    )

--- a/templates/pylibrary/pyproject.toml
+++ b/templates/pylibrary/pyproject.toml
@@ -1,0 +1,30 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+
+[tool.poetry.dependencies]
+
+[tool.poetry.dev-dependencies]
+black = "^22.3.0"
+flake8 = "^4.0.1"
+pytest = "^7.1.2"
+pyright = "^1.1.258"
+
+[tool.black]
+line-length = 100
+target-version = ['py39']
+
+[tool.pyright]
+reportMissingParameterType = true
+strictListInference = true
+strictDictionaryInference = true
+strictSetInference = true
+
+[tool.pylint."messages control"]
+disable = "all"
+enable = ["empty-docstring", "missing-module-docstring", "missing-class-docstring", "missing-function-docstring"]
+ignore = ["setup.py", "__init__.py"]
+ignore-paths = ["tests"]
+

--- a/templates/pylibrary/tests/test_template.py
+++ b/templates/pylibrary/tests/test_template.py
@@ -1,0 +1,29 @@
+"""
+Check that the template works as intended.
+"""
+
+import pathlib
+import tempfile
+
+import cookiecutter.main
+
+TEMPLATE_DIRECTORY = str(pathlib.Path(__file__).parent.parent)
+
+
+def test_template():
+    """
+    Check that the template works with a vanilla cookiecutter call.
+    """
+    with tempfile.TemporaryDirectory(suffix="test-template") as tmp_dir:
+        cookiecutter.main.cookiecutter(
+            template=TEMPLATE_DIRECTORY,
+            output_dir=str(tmp_dir),
+            no_input=True,
+            accept_hooks=False,  # Don't test the hooks as these dont work on github
+        )
+
+        output_paths = {
+            str(path.relative_to(tmp_dir)) for path in pathlib.Path(tmp_dir).glob("**/*")
+        }
+
+        assert "library_name/pyproject.toml" in output_paths

--- a/templates/pylibrary/{{cookiecutter.module_name}}/README.md
+++ b/templates/pylibrary/{{cookiecutter.module_name}}/README.md
@@ -1,0 +1,36 @@
+# {{ cookiecutter.package_name }}
+
+{{ cookiecutter.package_description }}
+
+The project owner is [{{ cookiecutter.owner_github_handle }}](https://github.com/{{ cookiecutter.owner_github_handle.replace('@', '') }}).
+
+## Development
+
+If not already in a virtual environement, create and use one.
+Read about it in the Python documentation: [venv — Creation of virtual environments](https://docs.python.org/3/library/venv.html).
+
+```
+python3 -m venv .venv
+source .venv/bin/activate
+```
+
+Install the pinned pip version:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/pip-requirements.txt
+```
+
+Finally, install the dependencies:
+
+```
+pip install -r $(git rev-parse --show-toplevel)/dev-requirements.txt -r requirements.txt
+```
+
+## Testing
+
+Execute tests from the library's folder (after having loaded the virtual environment,
+see above) as follows:
+
+```
+python3 -m pytest tests/
+```

--- a/templates/pylibrary/{{cookiecutter.module_name}}/pyproject.toml
+++ b/templates/pylibrary/{{cookiecutter.module_name}}/pyproject.toml
@@ -1,0 +1,37 @@
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"
+
+[tool.poetry]
+name = "mycorp-{{ cookiecutter.package_name }}"
+version = "0.0.1"
+description = "{{ cookiecutter.package_description }}"
+authors = [
+    "{{ cookiecutter.owner_full_name }} <{{ cookiecutter.owner_email_address }}>"
+]
+packages = [
+  { include = "mycorp" }
+]
+
+[tool.poetry.dependencies]
+python = ">=3.9"
+
+[tool.poetry.dev-dependencies]
+black = "^23.1.0"
+flake8 = "^6.0.0"
+isort = "^5.12.0"
+pylint = "^2.16.3"
+pyright = "^1.1.296"
+pytest = "^7.2.1"
+
+[tool.black]
+line-length = 100
+target-version = ['py39']
+
+[tool.pyright]
+
+[tool.pylint."messages control"]
+disable = "all"
+enable = ["empty-docstring", "missing-module-docstring", "missing-class-docstring", "missing-function-docstring"]
+ignore = ["setup.py", "__init__.py"]
+ignore-paths = ["tests"]

--- a/templates/pylibrary/{{cookiecutter.module_name}}/requirements.txt
+++ b/templates/pylibrary/{{cookiecutter.module_name}}/requirements.txt
@@ -1,0 +1,2 @@
+# Add pinned dependencies to install for development
+# Development dependencies (black, flake8, etc.) are in the top-level dev-requirements.txt file

--- a/templates/pylibrary/{{cookiecutter.module_name}}/setup.cfg
+++ b/templates/pylibrary/{{cookiecutter.module_name}}/setup.cfg
@@ -1,0 +1,1 @@
+# This file is empty, but is needed by setuptools to detect pyproject.toml (for now)

--- a/templates/pylibrary/{{cookiecutter.module_name}}/tests/conftest.py
+++ b/templates/pylibrary/{{cookiecutter.module_name}}/tests/conftest.py
@@ -1,0 +1,13 @@
+"""
+Shared configuration and fixtures for pytest.
+"""
+
+import pytest
+
+
+@pytest.fixture
+def some_text() -> str:
+    """
+    Some fixture which can be reused in all test modules.
+    """
+    return "Some text"

--- a/templates/pylibrary/{{cookiecutter.module_name}}/tests/test_example.py
+++ b/templates/pylibrary/{{cookiecutter.module_name}}/tests/test_example.py
@@ -1,0 +1,8 @@
+"""
+An example of test module provided by the project template.
+"""
+
+
+def test_something():
+    """An example of test found and run by pytest."""
+    raise NotImplementedError("No test was implemented. Either remove this test or implement it.")


### PR DESCRIPTION
## What this PR does

* This PR adds a cookiecutter template to create new libraries
* It augments the CI so that the template is called and generated files are checked like existing files

## How to trust this PR

Install cookiecutter in the repo:

```
python3 -m venv .venv
source .venv/bin/activate
pip install -r pip-requirements.txt
pip install -r dev-requirements.txt
```

Then generate a new library:

```
cookiecutter --no-input templates/pylibrary --output-dir libs/
```

Check that the library's CI passes:

```
act workflow_dispatch -j libs-library_name-ci
```

Check that the generated library is consistent with existing libraries:

```
meld libs/base libs/library_name
```

* Inspect that the CI on a generated library is fine, see https://github.com/tweag/python-monorepo-example/pull/5
* Install `libs/base` or `libs/fancy` locally using the new `README.md` and witness the instructions work fine.

## Notes

* I will make the tests within `base` and `fancy` meaningful in another PR.
* I will maybe add CODEOWNERS augmentation in the template in another PR.