### PR TITLE
Make tests of libs/base pass

### DIFF
--- a/.mergify.yml
+++ b/.mergify.yml
@@ -10,7 +10,7 @@ pull_request_rules:
     actions:
       queue:
         name: default
-        method: merge
+        method: rebase
 
   - name: delete head branch after merge
     conditions:

--- a/libs/base/tests/test_example.py
+++ b/libs/base/tests/test_example.py
@@ -1,8 +1,24 @@
 """
-An example of test module provided by the project template.
+Tests of adder2
 """
 
+from mycorp import base
 
-def test_something():
-    """An example of test found and run by pytest."""
-    raise NotImplementedError("No test was implemented. Either remove this test or implement it.")
+
+def test_zero() -> None:
+    """Tests the neutral element"""
+    assert base.adder2.add2(0, 0) == 0
+    assert base.adder2.add2(0, 3) == 3
+    assert base.adder2.add2(0, 3) == base.adder2.add2(3, 0)
+
+
+def test_some() -> None:
+    """Some unit tests"""
+    assert base.adder2.add2(1, 3) == 4
+    assert base.adder2.add2(1, 3) == base.adder2.add2(3, 1)
+    assert base.adder2.add2(100, 2) == (base.adder2.add2(100, 1) + base.adder2.add2(1, 0))
+
+
+# In a true repository we would add property tests here,
+# using hypothesis:
+# https://hypothesis.readthedocs.io/en/latest/


### PR DESCRIPTION
## What this PR does

This PR replaces the test boilerplate of `libs/base` (that fails) with meaningful tests that pass. It will make for a smoother experience for people using this template repository.

## How to trust this PR

1. The CI passes (note that it doesn't execute tests yet, this will be done when I fix `fancy`'s tests)
2. Executes `libs/base` tests locally and witness they pass:

```shell
cd libs/base
python3 -m venv .venv
source .venv/bin/activate
pip install -r ../../pip-requirements.txt
pip install -r ../../dev-requirements.txt -r requirements.txt
python3 -m pytest
```