### PR TITLE
CI: turn tests ON + libs/fancy: make tests pass

### DIFF
--- a/.github/workflows/ci_python_reusable.yml
+++ b/.github/workflows/ci_python_reusable.yml
@@ -58,3 +58,7 @@ jobs:
       - name: Typecheck
         run: |
           pyright .
+
+      - name: Test
+        run: |
+          python3 -m pytest tests/  # Assume that tests are in folder "tests/"

--- a/libs/base/tests/test_base.py
+++ b/libs/base/tests/test_base.py
@@ -13,7 +13,7 @@ def test_zero() -> None:
 
 
 def test_some() -> None:
-    """Some unit tests"""
+    """Some unit tests of add2"""
     assert base.adder2.add2(1, 3) == 4
     assert base.adder2.add2(1, 3) == base.adder2.add2(3, 1)
     assert base.adder2.add2(100, 2) == (base.adder2.add2(100, 1) + base.adder2.add2(1, 0))

--- a/libs/fancy/README.md
+++ b/libs/fancy/README.md
@@ -2,7 +2,7 @@
 
 A Python package by mycorp.
 
-The project owner is by our gentleman [@GuillaumeDesforges](https://github.com/GuillaumeDesforges).
+The project owner is our gentleman [@GuillaumeDesforges](https://github.com/GuillaumeDesforges).
 
 ## Development
 

--- a/libs/fancy/mycorp/fancy/__init__.py
+++ b/libs/fancy/mycorp/fancy/__init__.py
@@ -1,0 +1,3 @@
+from mycorp.fancy import adder3
+
+__all__ = ["adder3"]

--- a/libs/fancy/pyproject.toml
+++ b/libs/fancy/pyproject.toml
@@ -14,6 +14,7 @@ packages = [
 [tool.poetry.dependencies]
 python = ">=3.9"
 numpy = ">=1.21"
+mycorp-base = "*"
 
 [tool.poetry.dev-dependencies]
 black = "^23.1.0"

--- a/libs/fancy/tests/test_example.py
+++ b/libs/fancy/tests/test_example.py
@@ -1,8 +1,0 @@
-"""
-An example of test module provided by the project template.
-"""
-
-
-def test_something():
-    """An example of test found and run by pytest."""
-    raise NotImplementedError("No test was implemented. Either remove this test or implement it.")

--- a/libs/fancy/tests/test_fancy.py
+++ b/libs/fancy/tests/test_fancy.py
@@ -2,7 +2,10 @@
 Tests of adder3
 """
 
-from mycorp import base, fancy
+# from mycorp import base, fancy # don't! This makes pyright not able to link
+# one of the two packages (is it https://github.com/microsoft/pyright/issues/2882?)
+from mycorp import base
+from mycorp import fancy
 
 
 def test_zero() -> None:

--- a/libs/fancy/tests/test_fancy.py
+++ b/libs/fancy/tests/test_fancy.py
@@ -1,0 +1,31 @@
+"""
+Tests of adder3
+"""
+
+from mycorp import base, fancy
+
+
+def test_zero() -> None:
+    """Test of add3 with zero"""
+    assert fancy.adder3.add3(0, 0, 0) == 0
+    assert fancy.adder3.add3(0, 1, 0) == 1
+    assert fancy.adder3.add3(0, 1, 2) == 3
+    assert fancy.adder3.add3(1, 2, 0) == 3
+
+
+def test_add2_add3() -> None:
+    """Test relation between add2 and add3"""
+    assert fancy.adder3.add3(1, 2, 3) == (base.adder2.add2(1, 2) + base.adder2.add2(0, 3))
+    assert fancy.adder3.add3(1, 2, 0) == base.adder2.add2(1, 2)
+
+
+def test_some() -> None:
+    """Some unit tests of add3"""
+    assert fancy.adder3.add3(1, 2, 3) == 6
+    assert fancy.adder3.add3(1, 2, 3) == fancy.adder3.add3(3, 2, 1)
+    assert fancy.adder3.add3(100, 2, 3) == 105
+
+
+# In a true repository we would add property tests here,
+# using hypothesis:
+# https://hypothesis.readthedocs.io/en/latest/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,5 +31,6 @@ ignore-paths = ['.*/tests', ]
 profile = "black"
 line_length = 100
 auto_identify_namespace_packages = false
+force_single_line = true # pyright doesn't like implicit namespace + single line (related to https://github.com/microsoft/pyright/issues/2882?)
 known_first_party = ["mycorp"]
 extend_skip = ["archives"]


### PR DESCRIPTION
## What this PR does

1. This PR makes the tests of `libs/fancy` pass, by writing true tests instead of having the template boilerplate test file
2. As a consequence, this PR can turn tests ON in the CI, since they now pass both in `libs/base` and `libs/fancy`

## How to trust this PR

1. Observe that the CI executes tests and passes
2. Executes tests of `libs/fancy` locally and witness they work:

```shell
cd libs/fancy
python3 -m venv .venv
source .venv/bin/activate
pip install -r ../../pip-requirements.txt
pip install -r ../../dev-requirements.txt -r requirements.txt
python3 -m pytest
```